### PR TITLE
Reset player question count after round

### DIFF
--- a/web/firebase-modular.js
+++ b/web/firebase-modular.js
@@ -332,6 +332,15 @@ async function finalizeRound(gameCode, newDistribution, newVisibility) {
         
         // Limpiar campo nextDeath
         updateData.nextDeath = deleteField();
+
+        // Resetear contadores de preguntas al finalizar la ronda
+        const totalPlayers = currentData.totalPlayers || Object.values(newDistribution).flat().length;
+        const numberQuestionsMadeReset = {};
+        for (let i = 1; i <= totalPlayers; i++) {
+            numberQuestionsMadeReset[i] = 0;
+        }
+        updateData.numberQuestionsMade = numberQuestionsMadeReset;
+
         await updateDoc(doc(db, 'games', gameCode), updateData);
         console.log('✅ Ronda finalizada, visibilidad recalculada');
         return true;


### PR DESCRIPTION
Resets player question counts (`numberQuestionsMade`) at the end of each round to fix a bug.

Previously, the `numberQuestionsMade` field in the database was not cleared when a round concluded, leading to incorrect accumulation of 'I's (question marks) across rounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-69f76eb0-597a-457e-9bbb-6a0903339c2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69f76eb0-597a-457e-9bbb-6a0903339c2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

