### PR TITLE
Implement single target for assassin and accomplice

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1715,6 +1715,16 @@
             const roleElement = document.getElementById('player-role');
             const profileTitleElement = document.getElementById('profile-title');
             const roleInfoElement = document.getElementById('role-info');
+            let targetInfoElement = document.getElementById('target-info');
+            if (!targetInfoElement) {
+                targetInfoElement = document.createElement('div');
+                targetInfoElement.id = 'target-info';
+                targetInfoElement.className = 'role-info';
+                // Insertar debajo del role-info existente
+                if (roleInfoElement && roleInfoElement.parentNode) {
+                    roleInfoElement.parentNode.insertBefore(targetInfoElement, roleInfoElement.nextSibling);
+                }
+            }
             
             if (!profileElement || !roleElement || !profileTitleElement || !roleInfoElement) return;
             
@@ -1760,6 +1770,16 @@
                 // Para invitados, no mostrar información adicional
                 roleInfoElement.style.display = 'none';
                 console.log(`👤 INVITADO ${playerNumber} no puede ver información adicional de roles`);
+            }
+
+            // Mostrar objetivo del asesino para ASESINO y COMPLICE
+            const target = window.gameData && typeof window.gameData.targetAsesino === 'number' ? window.gameData.targetAsesino : null;
+            if ((role === 'ASESINO/A' || role === 'COMPLICE') && target) {
+                targetInfoElement.textContent = `OBJETIVO: JUG. ${target}`;
+                targetInfoElement.style.display = 'block';
+                console.log(`🎯 ${role} ve el objetivo: JUG. ${target}`);
+            } else {
+                if (targetInfoElement) targetInfoElement.style.display = 'none';
             }
             
             // Mostrar el perfil


### PR DESCRIPTION
Adds a specific target for the assassin and accomplice, displayed upon game reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cdc5008-34e7-4b75-898a-e28cfbe23180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cdc5008-34e7-4b75-898a-e28cfbe23180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

